### PR TITLE
Fix Time Sync Message parsing

### DIFF
--- a/include/TimeSync.hpp
+++ b/include/TimeSync.hpp
@@ -30,7 +30,7 @@ namespace time_sync {
      * TimeSyncMessage struct
      */
     struct TimeSyncMessage {
-        unsigned long timestamp;
+        unsigned long timestep;
         unsigned long seq;
     };
     /**
@@ -59,7 +59,7 @@ namespace time_sync {
              * @param ip IP address of the time sync server
              * @param port Port of the time sync server
              */
-            TimeSync(const std::string &ip = "127.0.0.1", unsigned int port = 4567);
+            TimeSync(const std::string &ip = "127.0.0.1", unsigned int port = 4567, bool debug = false);
             /**
              * If in simulation mode, starts independent thread to consume time sync messages and update carma-clock
              */

--- a/src/TimeSync.cpp
+++ b/src/TimeSync.cpp
@@ -16,7 +16,11 @@
 #include "TimeSync.hpp"
 
 namespace time_sync {
-    TimeSync::TimeSync(const std::string &ip , unsigned int port ) : initialized(false), _ip(ip), _port(port)  {}
+    TimeSync::TimeSync(const std::string &ip , unsigned int port, bool debug ) : initialized(false), _ip(ip), _port(port)  {
+        if (debug) {
+            spdlog::set_level(spdlog::level::debug);
+        }
+    }
  
     void TimeSync::start() {
         if (!initialized) {
@@ -52,7 +56,7 @@ namespace time_sync {
                     SPDLOG_DEBUG("TimeSync initialized!");
                 }
                 auto message = readTimeSyncMessage(time_sync);
-                ClockSingleton::update(message.timestamp);
+                ClockSingleton::update(message.timestep);
                 if (_performance_logging) {
                     if(auto logger = spdlog::get("performance"); logger != nullptr ){
                         logger->info("{0},{1}", 
@@ -107,10 +111,10 @@ namespace time_sync {
         if (document.HasParseError()) {
             throw std::runtime_error( "Parsing error: " + document.GetParseError() );
         }
-        if (!document.IsObject() || !document.HasMember("timestamp") || !document["timestamp"].IsUint64()) {
+        if (!document.IsObject() || !document.HasMember("timestep") || !document["timestep"].IsUint64()) {
             throw std::runtime_error( "Parsing error: time sync message " + time_sync + " is not a valid time sync message!" );    
         }
-        message.timestamp =  document["timestamp"].GetUint64();
+        message.timestep =  document["timestep"].GetUint64();
         if (!document.IsObject() || !document.HasMember("seq") || !document["seq"].IsUint64()) {
             throw std::runtime_error( "Parsing error: time sync message " + time_sync + " is not a valid time sync message!" );    
         }

--- a/test/TestTimeSync.cpp
+++ b/test/TestTimeSync.cpp
@@ -34,9 +34,9 @@ TEST(TimeSync, now) {
 
 TEST(TimeSync, readTimeSyncMessage) {
 
-    std::string time_sync_message = "{\"timestamp\": 1231, \"seq\": 1000}";
+    std::string time_sync_message = "{\"timestep\": 1231, \"seq\": 1000}";
     auto timeSyncMessage = time_sync::readTimeSyncMessage(time_sync_message);
-    EXPECT_EQ(timeSyncMessage.timestamp, 1231);
+    EXPECT_EQ(timeSyncMessage.timestep, 1231);
     EXPECT_EQ(timeSyncMessage.seq, 1000);
 }
 
@@ -44,7 +44,7 @@ TEST(TimeSync, readTimeSyncMessageInvalid) {
 
     std::string time_sync_message = "{\"something\": 1231, \"seq\": 1000}";
     EXPECT_THROW( time_sync::readTimeSyncMessage(time_sync_message), std::runtime_error);
-    time_sync_message = "{\"timestamp\": 1231, \"something\": 1000}";
+    time_sync_message = "{\"timestep\": 1231, \"something\": 1000}";
     EXPECT_THROW( time_sync::readTimeSyncMessage(time_sync_message), std::runtime_error);
     time_sync_message = "invalidJson";
     EXPECT_THROW( time_sync::readTimeSyncMessage(time_sync_message), std::runtime_error);
@@ -57,7 +57,7 @@ TEST(TimeSync, testStart) {
     time_sync::TimeSync sync;
     sync.start();  
     udp_socket::UdpClient client("127.0.0.1", 4567);
-    std::string time_sync_message = "{\"timestamp\": 1231, \"seq\": 1000}";
+    std::string time_sync_message = "{\"timestep\": 1231, \"seq\": 1000}";
     client.Send(time_sync_message);
     EXPECT_EQ(time_sync::nowInMilliseconds(), 1231); 
     EXPECT_NO_THROW(time_sync::sleepUntil(1231));

--- a/test/python_timesync_test.py
+++ b/test/python_timesync_test.py
@@ -24,7 +24,7 @@ class TestCarmaClock(unittest.TestCase):
         # Create a UDP socket
         client_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         # Send data to the server
-        message = r'{ "timestamp": 100, "seq": 1}'
+        message = r'{ "timestep": 100, "seq": 1}'
         client_socket.sendto(message.encode('utf-8'), SERVER_ADDRESS)
 
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Correct message parsing to look for json
```json
{
"timestep": 123,
"seq":123
}
```

Also included new debug argument to enable debug logs
<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
TT-157
## Motivation and Context
Bug fix
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
